### PR TITLE
Fix the bugs in initialize.sh

### DIFF
--- a/contracts/crowdfund/src/lib.rs
+++ b/contracts/crowdfund/src/lib.rs
@@ -32,8 +32,10 @@ fn get_contract_id(e: &Env) -> Identifier {
     Identifier::Contract(e.get_current_contract().into())
 }
 
-fn get_ledger_timestamp(e: &Env) -> u64 {
-    e.ledger().timestamp()
+fn get_ledger_timestamp(_e: &Env) -> u64 {
+    // TODO: Use this once we can get the ledger timestamp. For now it panics with "missing ledger info", as in soroban-cli we aren't setting up the ledger.
+    // e.ledger().timestamp()
+    1
 }
 
 fn get_owner(e: &Env) -> Identifier {
@@ -110,12 +112,15 @@ impl Crowdfund {
     pub fn initialize(
         e: Env,
         owner: Identifier,
-        deadline: u64,
+        deadline: i64,
         target_amount: BigInt,
         token: BytesN<32>,
     ) {
         if e.contract_data().has(DataKey::Owner) {
             panic!("already initialized");
+        }
+        if deadline < 0 {
+            panic!("deadline must be positive");
         }
         e.contract_data().set(DataKey::Owner, owner);
         e.contract_data()

--- a/initialize.sh
+++ b/initialize.sh
@@ -24,10 +24,10 @@ echo Deploy the crowdfund contract
 soroban-cli deploy --id 0 --wasm target/wasm32-unknown-unknown/release/soroban_crowdfund_contract.wasm
 
 echo Initialize the crowdfund contract
-deadline=$(date +"%s")
+deadline="$(($(date +"%s") + 86400))"
 soroban-cli invoke --id 0 \
   --fn initialize \
   --arg-xdr "$admin" \
-  --arg "$((deadline + 86400))" \
+  --arg "$deadline" \
   --arg "1000000000" \
   --arg '[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]'

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "setup": "./initialize.sh",
     "dev": "next dev",
     "build": "next build",
     "start": "next start",


### PR DESCRIPTION
Turns out we can't pass u64 in from the CLI (panics). Use an i64 instead. This was confusing

We also don't have a ledger timestamp injected from the soroban-cli yet. So comment that out for now.

Workaround for https://github.com/stellar/soroban-example-dapp/issues/6 by working around the issues.

Opened https://github.com/stellar/soroban-cli/issues/116 and https://github.com/stellar/soroban-cli/issues/117 to fix the underlying issues.