### PR TITLE
Fix re-entrancy attack bug in example contract.

### DIFF
--- a/contracts/crowdfund/src/lib.rs
+++ b/contracts/crowdfund/src/lib.rs
@@ -223,8 +223,8 @@ impl Crowdfund {
 
                 // Withdraw full amount
                 let balance = get_user_deposited(&e, &to);
-                transfer(&e, get_token(&e), &to, &balance);
                 set_user_deposited(&e, &to, BigInt::zero(&e));
+                transfer(&e, get_token(&e), &to, &balance);
             }
         };
     }


### PR DESCRIPTION
Not a real issue in this case, as it could only be exploited by a malicious token contract. But better to set a good example.

[More Info on re-entrancy attacks](https://solidity-by-example.org/hacks/re-entrancy/)