### PR TITLE
Remove crate-type rlib from build config

### DIFF
--- a/contracts/crowdfund/Cargo.toml
+++ b/contracts/crowdfund/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 
 [features]
 default = ["export"]


### PR DESCRIPTION
### What
Remove crate-type rlib from build config.

### Why
When rust builds two crate types at once some optimizations are disabled (e.g. LTO) is disabled, which results in bloated .wasm files. We don't need rlib enabled because we're building a .wasm file, and not a library.

### Before

Build with stable + wasm-opt:
```
-rw-r--r--  1 leighmcculloch  staff  13841 Oct 31 08:17 soroban_crowdfund_contract.wasm
```
Build with nightly + wasm-opt:
```
-rw-r--r--  1 leighmcculloch  staff  9151 Oct 31 08:17 soroban_crowdfund_contract.wasm
```

### After
Build with stable + wasm-opt:
```
-rw-r--r--  1 leighmcculloch  staff  6966 Oct 31 08:17 soroban_crowdfund_contract.wasm
```
Build with nightly + wasm-opt:
```
-rw-r--r--  1 leighmcculloch  staff  6323 Oct 31 08:17 soroban_crowdfund_contract.wasm
```