### PR TITLE
Use stellar/actions/rust-cache and stellar/binaries in ci

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,26 +40,13 @@ jobs:
     runs-on: ${{ matrix.sys.os }}
     steps:
     - uses: actions/checkout@v3
+    - uses: stellar/actions/rust-cache@main
     - run: rustup update
     - run: rustup target add ${{ matrix.sys.target }}
-    - uses: actions/cache@v3
+    - uses: stellar/binaries@v12
       with:
-        path: |
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-        key: cargo-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: cargo-
-    - uses: actions/cache@v3
-      with:
-        path: target/
-        key: ${{ github.job }}-target-${{ strategy.job-index }}-${{ github.sha }}
-        restore-keys: |
-          ${{ github.job }}-target-${{ strategy.job-index }}
-          ${{ github.job }}-target-
-    - if: github.ref_protected
-      run: rm -fr target
-    - run: cargo install --locked --version 0.5.16 cargo-hack
+        name: cargo-hack
+        version: 0.5.16
     - run: cargo check --profile ${{ matrix.sys.profile }} --target ${{ matrix.sys.target }} --lib
     - if: matrix.sys.test
       run: cargo hack --feature-powerset check --profile ${{ matrix.sys.profile }} --target ${{ matrix.sys.target }} --bins --tests --examples --benches


### PR DESCRIPTION
### What
In CI jobs use stellar/actions/rust-cache to cache rust builds, and stellar/binaries to install binary tools.

### Why
It looks like I missed updating this repo when we improved the caching logic for Rust builds and moved it into an action. Also just recently moved to installing binaries from prebuilds rather than from source.

### Merging

This PR will conflict with #53, and should be updated and merged after #53.