### PR TITLE
Followup clean up of builds and makefile

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,11 +31,9 @@ jobs:
         sys:
         - os: ubuntu-latest
           target: wasm32-unknown-unknown
-          profile: release
           test: false
         - os: ubuntu-latest
           target: x86_64-unknown-linux-gnu
-          profile: test
           test: true
     runs-on: ${{ matrix.sys.os }}
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,13 +43,9 @@ jobs:
     - uses: stellar/actions/rust-cache@main
     - run: rustup update
     - run: rustup target add ${{ matrix.sys.target }}
-    - uses: stellar/binaries@v12
-      with:
-        name: cargo-hack
-        version: 0.5.16
-    - run: cargo clippy --profile ${{ matrix.sys.profile }} --target ${{ matrix.sys.target }} --lib
+    - run: cargo clippy --target ${{ matrix.sys.target }} --lib
+    - if: matrix.sys.target != 'wasm32-unknown-unknown'
+      run: cargo clippy --target ${{ matrix.sys.target }} --bins --tests --examples --benches
+    - run: cargo build --target ${{ matrix.sys.target }}
     - if: matrix.sys.test
-      run: cargo hack --feature-powerset clippy --profile ${{ matrix.sys.profile }} --target ${{ matrix.sys.target }} --bins --tests --examples --benches
-    - run: cargo build --profile ${{ matrix.sys.profile }} --target ${{ matrix.sys.target }}
-    - if: matrix.sys.test
-      run: cargo hack --feature-powerset test --profile ${{ matrix.sys.profile }} --target ${{ matrix.sys.target }}
+      run: cargo test --target ${{ matrix.sys.target }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -659,7 +659,6 @@ version = "0.0.0"
 dependencies = [
  "rand 0.7.3",
  "soroban-auth",
- "soroban-crowdfund-contract",
  "soroban-sdk",
  "stellar-xdr",
 ]

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ build: fmt
 		done
 
 check: fmt
-	cargo check --all-targets
-	cargo check --release --target wasm32-unknown-unknown
+	cargo clippy --all-targets
+	cargo clippy --release --target wasm32-unknown-unknown
 
 watch:
 	cargo watch --clear --watch-when-idle --shell '$(MAKE)'

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ build: fmt
 		done
 
 check: fmt
-	cargo hack --feature-powerset check --all-targets
+	cargo check --all-targets
 	cargo check --release --target wasm32-unknown-unknown
 
 watch:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 all: check build test
 
-export RUSTFLAGS=-Dwarnings
+export RUSTFLAGS=-Dwarnings -Dclippy::all -Dclippy::pedantic
 
 test: fmt
 	cargo test

--- a/contracts/crowdfund/Cargo.toml
+++ b/contracts/crowdfund/Cargo.toml
@@ -7,11 +7,6 @@ publish = false
 [lib]
 crate-type = ["cdylib"]
 
-[features]
-default = ["export"]
-export = []
-testutils = ["soroban-sdk/testutils", "soroban-auth/testutils", "dep:stellar-xdr"]
-
 [dependencies]
 soroban-sdk = { version = "0.1.0" }
 soroban-auth = { version = "0.1.0" }
@@ -20,5 +15,4 @@ stellar-xdr = { version = "0.0.6", features = ["next", "std"], optional = true }
 [dev_dependencies]
 soroban-sdk = { version = "0.1.0", features = ["testutils"] }
 soroban-auth = { version = "0.1.0", features = ["testutils"] }
-soroban-crowdfund-contract = { path = ".", default-features = false, features = ["testutils"] }
 rand = { version = "0.7.3" }

--- a/contracts/crowdfund/src/lib.rs
+++ b/contracts/crowdfund/src/lib.rs
@@ -7,7 +7,7 @@ mod token {
 }
 
 mod test;
-pub mod testutils;
+mod testutils;
 
 #[derive(Clone)]
 #[contracttype]

--- a/contracts/crowdfund/src/test.rs
+++ b/contracts/crowdfund/src/test.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 
+use super::testutils::{register_test_contract as register_crowdfund, Crowdfund};
 use super::token::{Client as Token, TokenMetadata};
-use crate::testutils::{register_test_contract as register_crowdfund, Crowdfund};
 use rand::{thread_rng, RngCore};
 use soroban_auth::{Identifier, Signature};
 use soroban_sdk::{

--- a/contracts/crowdfund/src/testutils.rs
+++ b/contracts/crowdfund/src/testutils.rs
@@ -1,4 +1,4 @@
-#![cfg(any(test, feature = "testutils"))]
+#![cfg(test)]
 
 use crate::CrowdfundClient;
 


### PR DESCRIPTION
### What
Remove unused features. Use clippy in Makefile. Remove cargo-hack. Remove profiles.

### Why
Recently we've made a few changes like only generating a cdylib, and adding clippy to CI. These changes left somethings we can clean up.

If we're only building a cdylib, we can't really offer testutils to other crates, and no crate currently imports the lib and we shouldn't encourage that due to the impact it has on .wasm size. (See #51 for why.) This means we don't need the testutils feature.

We also don't need the export feature, we don't use it anymore.

If we don't have any features we don't really need cargo-hack in a single crate workspace.

Setting profiles is mostly unnecessary. We don't do it in other crates anymore and just let cargo use the defaults for the respective commands.