### PR TITLE
fix: rename 'standalone' to 'localnet', get it working

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ backed by smart contracts on Stellar.
 ### Dependencies
 
 1. Install the soroban-cli from https://soroban.stellar.org/docs/getting-started/setup#install-the-soroban-cli
-2. Install Docker for Standalone and Futurenet backends.
+2. Install Docker for Localnet and Futurenet backends.
 
 ### Backend (Local Sandbox)
 
@@ -30,10 +30,10 @@ backed by smart contracts on Stellar.
     | Allow HTTP connection | Enabled |
     | Switch to this network | Enabled |
 
-### Backend (Local Standalone Network)
+### Backend (Local Localnet Network)
 
-1. Run the backend docker container with `./quickstart.sh standalone`, and wait for it to start.
-2. Run `./initialize.sh standalone` to load the contracts and initialize it.
+1. Run the backend docker container with `./quickstart.sh localnet`, and wait for it to start.
+2. Run `./initialize.sh localnet` to load the contracts and initialize it.
   - Note: this state will be lost if the quickstart docker container is removed.
 3. Configure Freighter
   a. Install the custom Freighter Soroban release from https://github.com/stellar/freighter/releases/tag/v2.6.0-beta.2
@@ -41,12 +41,12 @@ backed by smart contracts on Stellar.
   c. Add a custom network:
     |   |   |
     |---|---|
-    | Name | Standalone |
+    | Name | Localnet |
     | URL | http://localhost:8000/soroban/rpc |
-    | Passphrase | Standalone Network ; February 2017 |
+    | Passphrase | Localnet Network ; February 2017 |
     | Allow HTTP connection | Enabled |
     | Switch to this network | Enabled |
-4. Add some Standalone network lumens to your Freighter wallet.
+4. Add some Localnet network lumens to your Freighter wallet.
   a. Copy the address for your freighter wallet.
   b. Visit `http://localhost:8000/friendbot?addr=<your address>`
 

--- a/initialize.sh
+++ b/initialize.sh
@@ -50,7 +50,7 @@ mkdir -p .soroban
 echo "$TOKEN_ID" > .soroban/token_id
 
 echo Build the crowdfund contract
-make build
+make build-optimized
 
 echo Deploy the crowdfund contract
 CROWDFUND_ID="$(

--- a/initialize.sh
+++ b/initialize.sh
@@ -9,11 +9,11 @@ TOKEN_ADMIN="GDT2NORMZF6S2T4PT4OBJJ43OPD3GPRNTJG3WVVFB356TUHWZQMU6C3U"
 TOKEN_ADMIN_IDENTIFIER="AAAABAAAAAEAAAAAAAAAAgAAAAUAAAAHQWNjb3VudAAAAAAEAAAAAQAAAAcAAAAA56a6LMl9LU+PnxwUp5tzx7M+LZpNu1alDvvp0PbMGU8="
 
 case "$1" in
-standalone)
-  echo "Using standalone network"
+localnet)
+  echo "Using localnet network"
   export SOROBAN_RPC_HOST="http://localhost:8000"
   export SOROBAN_RPC_URL="$SOROBAN_RPC_HOST/soroban/rpc"
-  export SOROBAN_NETWORK_PASSPHRASE="Standalone Network ; February 2017"
+  export SOROBAN_NETWORK_PASSPHRASE="localnet Network ; February 2017"
   export SOROBAN_SECRET_KEY="SAKCFFFNCE7XAWYMYVRZQYKUK6KMUCDIINLWISJYTMYJLNR2QLCDLFVT"
 
   echo Fund token admin account from friendbot
@@ -32,7 +32,7 @@ futurenet)
   # no-op
   ;;
 *)
-  echo "Usage: $0 sandbox|standalone|futurenet"
+  echo "Usage: $0 sandbox|localnet|futurenet"
   exit 1
   ;;
 esac

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -7,7 +7,7 @@ import {
   getDefaultWallets,
 } from "../wallet";
 
-const chains: ChainMetadata[] = [chain.sandbox, chain.standalone, chain.futurenet];
+const chains: ChainMetadata[] = [chain.sandbox, chain.localnet, chain.futurenet];
 
 const { wallets } = getDefaultWallets({
   appName: "Example Stellar App",

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -3,16 +3,16 @@
 set -e
 
 case "$1" in
-standalone)
-    echo "Using standalone network"
-    ARGS="--standalone"
+localnet)
+    echo "Using localnet network"
+    ARGS="--localnet"
     ;;
 futurenet)
     echo "Using Futurenet network"
     ARGS="--futurenet"
     ;;
 *)
-    echo "Usage: $0 standalone|futurenet"
+    echo "Usage: $0 localnet|futurenet"
     exit 1
     ;;
 esac

--- a/wallet/provideWalletChains.tsx
+++ b/wallet/provideWalletChains.tsx
@@ -9,7 +9,7 @@ export type ChainName =
   | 'public'
   | 'testnet'
   | 'sandbox'
-  | 'standalone';
+  | 'localnet';
 
 export type ChainMetadata = WalletChain;
 
@@ -42,9 +42,9 @@ const chainMetadataByName: Record<ChainName, ChainMetadata> = {
     iconBackground: '#dac695',
     // iconUrl: async () => (await import('./chainIcons/futurenet.svg')).default,
   },
-  standalone: {
-    id: "standalone",
-    name: "Standalone",
+  localnet: {
+    id: "localnet",
+    name: "localnet",
     networkPassphrase: "Standalone Network ; February 2017",
     iconBackground: '#dac695',
     // iconUrl: async () => (await import('./chainIcons/futurenet.svg')).default,


### PR DESCRIPTION
When running in localnet mode, `initialize.sh` tries to deploy the optimized Wasm. So it also needs to `build-optimized`.


Also, the documentation [calls it][1] "localnet", not "standalone". It should either be renamed there or here.

  [1]: https://soroban.stellar.org/docs/tutorials/deploy-to-local-network