### PR TITLE
use docker image for soroban 0.3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ backed by smart contracts on Stellar.
 
 ### Dependencies
 
-1. Install the soroban-cli from https://soroban.stellar.org/docs/getting-started/setup#install-the-soroban-cli
+1. Install the soroban-cli from https://soroban.stellar.org/docs/getting-started/setup#install-the-soroban-cli. Using soroban v0.3.3
 2. Install Docker for Standalone and Futurenet backends.
 3. Node.js v17
 

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -21,7 +21,7 @@ docker run --rm -ti \
   --platform linux/amd64 \
   --name stellar \
   -p 8000:8000 \
-  stellar/quickstart:soroban-dev \
+  stellar/quickstart:soroban-dev@sha256:8046391718f8e58b2b88b9c379abda3587bb874689fa09b2ed4871a764ebda27 \
   $ARGS \
   --enable-soroban-rpc \
   --protocol-version 20


### PR DESCRIPTION
- fix a bug: fail to deploy contract when using soroban 0.3.3 and soroban-sdk 0.3.2