### PR TITLE
force docker image, when using soroban 0.3.3

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -21,7 +21,7 @@ docker run --rm -ti \
   --platform linux/amd64 \
   --name stellar \
   -p 8000:8000 \
-  stellar/quickstart:soroban-dev \
+  stellar/quickstart:soroban-dev@sha256:8046391718f8e58b2b88b9c379abda3587bb874689fa09b2ed4871a764ebda27 \
   $ARGS \
   --enable-soroban-rpc \
   --protocol-version 20


### PR DESCRIPTION
With the lastest commit https://github.com/stellar/soroban-example-dapp/commit/da61364736f7f5e0e6be8e3bb50891d92173c527 the following packages are used:

    rs-soroban-env [v0.0.11](https://github.com/stellar/rs-soroban-env/releases/tag/v0.0.11)
    rs-soroban-sdk [v0.3.2](https://github.com/stellar/rs-soroban-sdk/releases/tag/v0.3.2)
    rs-stellar-xdr [v0.0.11](https://github.com/stellar/rs-stellar-xdr/releases/tag/v0.0.11)
    js-soroban-client (npm package: soroban-client) [v0.2.1](https://github.com/stellar/js-soroban-client/releases/tag/v0.2.1)
    
 Following [leigh recommendation](https://discord.com/channels/897514728459468821/966788672164855829/1052065997856710778) the [recommended setups](https://soroban.stellar.org/docs/releases) say that: for this setup

    soroban-cli should be 0.3.3
    js-soroban-client should be in v0.2.0
    stellar quickstart docker should be: stellar/quickstart:soroban-dev@sha256:8046391718f8e58b2b88b9c379abda3587bb874689fa09b2ed4871a764ebda27
    
    
The commit in this pull request force the user to use the specific docker image

Follow the discussion here: https://github.com/stellar/soroban-example-dapp/issues/72