### PR TITLE
feat(docker-container): Draft: create docker image from Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,19 @@
+# Based on Preview 7
+# https://soroban.stellar.org/docs/reference/releases
+
+FROM ubuntu:20.04
+
+RUN apt update
+RUN apt install -y nano
+RUN apt install -y curl
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rust_install.sh
+RUN sh rust_install.sh -y
+RUN echo $PATH
+ENV PATH="$PATH:/root/.cargo/bin"
+RUN rustup target add wasm32-unknown-unknown
+
+RUN cargo install --locked --version 0.6.0 soroban-cli
+# WORKDIR /
+RUN mkdir /workspace
+WORKDIR /workspace

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Build image and tag it with image name and version
+docker build . \
+    --tag soroban-preview:7 \
+    --force-rm \
+    --rm


### PR DESCRIPTION
As introduced in https://github.com/stellar/soroban-example-dapp/issues/89, this PR (draft) introduces the creation of a Docker image with all the necessary dependencies (depending on the current release https://soroban.stellar.org/docs/reference/releases)

- rust
- soroban-cli

Tasks:

- [ ] Create Docker Image (soroban-preview:7)
- [ ] Start docker container with that image
- [ ] Make ./initialize.sh to work insithe this docker container
- [ ] Use docker-compose in order to run both this and stellar/quickstart:soroban-dev container