### PR TITLE
Fix env variable bug  and use docker hub image

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -44,7 +44,9 @@ docker run -dti \
   -p 8001:8000 \
   --ipc=host \
   --network soroban-network \
-  soroban-preview:7
+  -e IS_USING_DOCKER="true" \
+  esteblock/soroban-preview:7
+
 
 # Run the stellar quickstart image
 docker run --rm -ti \


### PR DESCRIPTION
- IS_USING_DOCKER was not set. There was a bug when executing ./initialize.sh inside the docker image
- I propose to use the docker hub image esteblock/soroban-preview:7, so users don't need to build it for themselves.