### PR TITLE
Update ubuntu to 22.04 from 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Based on Preview 7
 # https://soroban.stellar.org/docs/reference/releases
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 RUN apt update && apt install -y curl
 


### PR DESCRIPTION
 ### What:

 Update ubuntu to 22.04 from 20.04


### Why:
We are upgrading SDF infra to 22.04