### PR TITLE
Add rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "stable"
+targets = ["wasm32-unknown-unknown"]
+components = ["rustc", "cargo", "rustfmt", "clippy", "rust-src"]


### PR DESCRIPTION
### What
Add rust-toolchain.toml

### Why
So that developers when checking out the code base know which version of Rust they should be using, and so that tooling and IDEs can automatically select the specified rust tooling, targets, and components.

The file is already used in other code bases like the soroban-examples repo.

Close stellar/rs-soroban-env#1311