### PR TITLE
Fixeed Error: You Must Provide a signTransaction Function

### DIFF
--- a/components/molecules/form-pledge/index.tsx
+++ b/components/molecules/form-pledge/index.tsx
@@ -50,11 +50,10 @@ function MintButton({
         const tx = await abundance.mint({ to: account, amount: amount });
         const signedXdr = await signTransaction(tx.toXDR(), {
           network: 'TESTNET',
-          networkPassphrase: tx.raw.networkPassphrase,
         });
         let signed_tx = TransactionBuilder.fromXDR(
           signedXdr,
-          tx.raw.networkPassphrase
+          "Test SDF Network ; September 2015"
         );
         const txRes = await server.sendTransaction(signed_tx);
         setSubmitting(false)

--- a/components/molecules/form-pledge/index.tsx
+++ b/components/molecules/form-pledge/index.tsx
@@ -4,9 +4,9 @@ import { TransactionModal } from '../../molecules/transaction-modal'
 import { Utils } from '../../../shared/utils'
 import styles from './style.module.css'
 import { Spacer } from '../../atoms/spacer'
-import { abundance, crowdfund } from '../../../shared/contracts'
+import { abundance, crowdfund, server } from '../../../shared/contracts'
 import { signTransaction } from '@stellar/freighter-api'
-import { BASE_FEE, xdr } from '@stellar/stellar-sdk'
+import { BASE_FEE, TransactionBuilder, xdr } from '@stellar/stellar-sdk'
 
 export interface IFormPledgeProps {
   account: string
@@ -47,8 +47,16 @@ function MintButton({
       title={`Mint ${displayAmount} ${symbol}`}
       onClick={async () => {
         setSubmitting(true)
-        const tx = await abundance.mint({ to: account, amount: amount })
-        await tx.signAndSend()
+        const tx = await abundance.mint({ to: account, amount: amount });
+        const signedXdr = await signTransaction(tx.toXDR(), {
+          network: 'TESTNET',
+          networkPassphrase: tx.raw.networkPassphrase,
+        });
+        let signed_tx = TransactionBuilder.fromXDR(
+          signedXdr,
+          tx.raw.networkPassphrase
+        );
+        const txRes = await server.sendTransaction(signed_tx);
         setSubmitting(false)
         onComplete()
       }}


### PR DESCRIPTION
Fixeed Error: You Must Provide a signTransaction Function #159 

Made the below change to the `form-pledge` component , by which now it signs the transaction , builds the transaction using the TransactionBuilder and then sends the transaction using the server.

```
 const tx = await abundance.mint({ to: account, amount: amount });
        const signedXdr = await signTransaction(tx.toXDR(), {
          network: 'TESTNET',
          networkPassphrase: tx.raw.networkPassphrase,
        });
        let signed_tx = TransactionBuilder.fromXDR(
          signedXdr,
          tx.raw.networkPassphrase
        );
        const txRes = await server.sendTransaction(signed_tx);
```

Below screenshots as proof of the working.
![Screenshot 2024-07-08 163154](https://github.com/stellar/soroban-example-dapp/assets/95926324/bb7164cf-0b3e-425a-be8e-a7b0322a09bc)
![Screenshot 2024-07-08 163204](https://github.com/stellar/soroban-example-dapp/assets/95926324/78002c8f-0cdc-4ef0-b45a-c49022bc62ee)
![Screenshot 2024-07-08 163214](https://github.com/stellar/soroban-example-dapp/assets/95926324/967bf00b-7e7c-4cf3-99b0-97c1f48c417d)

