### PR TITLE
fixed the build error

### DIFF
--- a/contracts/abundance/src/test.rs
+++ b/contracts/abundance/src/test.rs
@@ -250,4 +250,3 @@ fn test_zero_allowance() {
     token.transfer_from(&spender, &from, &spender, &0);
     assert!(token.get_allowance(&from, &spender).is_none());
 }
-

--- a/contracts/abundance/src/test.rs
+++ b/contracts/abundance/src/test.rs
@@ -251,17 +251,3 @@ fn test_zero_allowance() {
     assert!(token.get_allowance(&from, &spender).is_none());
 }
 
-#[test]
-fn test_zero_allowance() {
-    // Here we test that transfer_from with a 0 amount does not create an empty allowance
-    let e = Env::default();
-    e.mock_all_auths();
-
-    let admin = Address::generate(&e);
-    let spender = Address::generate(&e);
-    let from = Address::generate(&e);
-    let token = create_token(&e, &admin);
-
-    token.transfer_from(&spender, &from, &spender, &0);
-    assert!(token.get_allowance(&from, &spender).is_none());
-}


### PR DESCRIPTION
closes #160  

the fn test_zero_allowance() was defined twice in the tests.rs file and this is one of the main contributors to the build error

<img width="1280" alt="Screenshot 2024-08-01 at 15 30 33" src="https://github.com/user-attachments/assets/59f81cc7-7ec1-4829-bfb1-b91dbd1c51d3">
